### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
           SUPABASE_URL: https://example.com
           SUPABASE_API_KEY: dummy
           SSO_REDIRECT_TO: http://localhost
-        run: pytest --cov=src
+        run: python -m pytest --cov=src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        env:
+          PYTHONPATH: ./src
+          SUPABASE_URL: https://example.com
+          SUPABASE_API_KEY: dummy
+          SSO_REDIRECT_TO: http://localhost
+        run: pytest --cov=src

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SupaUser simplifies the authentication process by isolating user management into
 
 ## Running Tests 🧪
 
-Use `pytest` to execute the unit tests. The environment variables required by the
+Use `python -m pytest` to execute the unit tests. The environment variables required by the
 application need to be present, and `PYTHONPATH` must include the `src` folder.
 
 ```bash
@@ -42,7 +42,7 @@ export PYTHONPATH=src
 export SUPABASE_URL=http://example.com
 export SUPABASE_API_KEY=dummy
 export SSO_REDIRECT_TO=http://localhost
-pytest
+python -m pytest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ SupaUser simplifies the authentication process by isolating user management into
 - `POST /login-with-email-and-password` – Autenticação tradicional.
 - `POST /login-with-sso` – Retorna a URL de redirecionamento para login com Gmail.
 
+## Running Tests 🧪
+
+Use `pytest` to execute the unit tests. The environment variables required by the
+application need to be present, and `PYTHONPATH` must include the `src` folder.
+
+```bash
+export PYTHONPATH=src
+export SUPABASE_URL=http://example.com
+export SUPABASE_API_KEY=dummy
+export SSO_REDIRECT_TO=http://localhost
+pytest
+```
+
+
 ## Contributing 🤝
 Contributions are welcome! Feel free to open issues or submit pull requests to help improve the project.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ starlette==0.46.1
 supabase==2.14.0
 typing_extensions==4.12.2
 urllib3==2.3.0
+httpx==0.27.0
 uvicorn==0.34.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import types
+
+# Ensure environment variables used by the application exist
+os.environ.setdefault("SUPABASE_URL", "http://test")
+os.environ.setdefault("SUPABASE_API_KEY", "test-key")
+os.environ.setdefault("SSO_REDIRECT_TO", "http://localhost")
+
+# Add src directory to Python path
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+
+# Provide a dummy supabase module if the real one is unavailable
+if "supabase" not in sys.modules:
+    supabase = types.ModuleType("supabase")
+    supabase.create_client = lambda url, key: types.SimpleNamespace(auth={})
+    sys.modules["supabase"] = supabase

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,59 @@
+import types
+from fastapi.testclient import TestClient
+from src.main import app
+import src.api.auth as auth_module
+
+client = TestClient(app)
+
+
+def test_healthcheck():
+    response = client.get("/healthcheck")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_login_with_email_and_password_success(mocker):
+    dummy = types.SimpleNamespace(
+        user=types.SimpleNamespace(id="user123"),
+        session=types.SimpleNamespace(
+            access_token="access",
+            refresh_token="refresh",
+            expires_in=3600,
+            expires_at=123456,
+        ),
+    )
+    mocker.patch.object(auth_module.AuthService, "login_with_email_and_password", return_value=dummy)
+    data = {"email": "test@example.com", "password": "secret"}
+    response = client.post("/login-with-email-and-password", json=data)
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_id": "user123",
+        "access_token": "access",
+        "refresh_token": "refresh",
+        "expires_in": 3600,
+        "expires_at": 123456,
+    }
+
+
+def test_login_with_email_and_password_failure(mocker):
+    mocker.patch.object(auth_module.AuthService, "login_with_email_and_password", side_effect=Exception("fail"))
+    data = {"email": "test@example.com", "password": "secret"}
+    response = client.post("/login-with-email-and-password", json=data)
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Internal Server Error"}
+
+
+def test_login_with_sso_success(mocker):
+    mocker.patch.object(auth_module.AuthService, "login_with_sso", return_value={"url": "http://example.com"})
+    data = {"provider": "google", "redirect_to": "http://localhost"}
+    response = client.post("/login-with-sso", json=data)
+    assert response.status_code == 200
+    assert response.json() == {"redirect_url": "http://example.com"}
+
+
+def test_login_with_sso_failure(mocker):
+    mocker.patch.object(auth_module.AuthService, "login_with_sso", side_effect=Exception("fail"))
+    data = {"provider": "google", "redirect_to": "http://localhost"}
+    response = client.post("/login-with-sso", json=data)
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Internal Server Error"}


### PR DESCRIPTION
## Summary
- add pytest configuration and route tests
- update requirements with httpx used by FastAPI testing utilities
- describe how to run tests in the README
- add GitHub Actions workflow to run tests on push and PR

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6841df13fe48832d86097b5e10f20eba