### PR TITLE
Add Microsoft SSO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SupaUser simplifies the authentication process by isolating user management into
 
 2. **Create your .env based on .env.example:**
    - Defina `SUPABASE_URL` e `SUPABASE_API_KEY`.
-   - Opcionalmente defina `SSO_REDIRECT_TO` para o callback do Google SSO.
+   - Opcionalmente defina `SSO_REDIRECT_TO` para o callback do SSO com Google ou Microsoft.
 
 3. **Run SupaUser with docker:**
    ```bash
@@ -30,7 +30,7 @@ SupaUser simplifies the authentication process by isolating user management into
 
 ## Endpoints
 - `POST /login-with-email-and-password` – Autenticação tradicional.
-- `POST /login-with-sso` – Retorna a URL de redirecionamento para login com Gmail.
+- `POST /login-with-sso` – Retorna a URL de redirecionamento para login com Google ou Microsoft.
 
 ## Running Tests 🧪
 

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -39,7 +39,11 @@ async def login_with_email_and_password(
         )
 
 
-@router.post("/login-with-sso", summary="Login with Gmail SSO", response_model=SSOLoginResponse)
+@router.post(
+    "/login-with-sso",
+    summary="Login with Google or Microsoft SSO",
+    response_model=SSOLoginResponse,
+)
 async def login_with_sso(
     credentials: UserSSOAuth,
     service: AuthService = Depends(get_auth_service),

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from enum import Enum
 
 from pydantic import BaseModel, EmailStr
 
@@ -11,8 +12,15 @@ class UserPhonePasswordAuth(BaseModel):
     phone: str
     password: str
 
+class OAuthProvider(str, Enum):
+    """Supported OAuth providers for SSO."""
+
+    GOOGLE = "google"
+    MICROSOFT = "azure"
+
+
 class UserSSOAuth(BaseModel):
-    provider: str
+    provider: OAuthProvider
     redirect_to: Optional[str] = None
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -51,6 +51,14 @@ def test_login_with_sso_success(mocker):
     assert response.json() == {"redirect_url": "http://example.com"}
 
 
+def test_login_with_sso_microsoft_success(mocker):
+    mocker.patch.object(auth_module.AuthService, "login_with_sso", return_value={"url": "http://example.com"})
+    data = {"provider": "azure", "redirect_to": "http://localhost"}
+    response = client.post("/login-with-sso", json=data)
+    assert response.status_code == 200
+    assert response.json() == {"redirect_url": "http://example.com"}
+
+
 def test_login_with_sso_failure(mocker):
     mocker.patch.object(auth_module.AuthService, "login_with_sso", side_effect=Exception("fail"))
     data = {"provider": "google", "redirect_to": "http://localhost"}


### PR DESCRIPTION
## Summary
- document SSO redirect with Google or Microsoft
- support `azure` provider for SSO
- mention Google or Microsoft SSO in docs and route summary
- test Microsoft SSO flow

## Testing
- `PYTHONPATH=src python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849899cfb54832d8b602deed4dcee19