### PR TITLE
Add GitHub login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SupaUser simplifies the authentication process by isolating user management into
 
 2. **Create your .env based on .env.example:**
    - Defina `SUPABASE_URL` e `SUPABASE_API_KEY`.
-   - Opcionalmente defina `SSO_REDIRECT_TO` para o callback do SSO com Google ou Microsoft.
+   - Opcionalmente defina `SSO_REDIRECT_TO` para o callback do SSO com Google, Microsoft ou GitHub.
 
 3. **Run SupaUser with docker:**
    ```bash
@@ -30,7 +30,7 @@ SupaUser simplifies the authentication process by isolating user management into
 
 ## Endpoints
 - `POST /login-with-email-and-password` – Autenticação tradicional.
-- `POST /login-with-sso` – Retorna a URL de redirecionamento para login com Google ou Microsoft.
+- `POST /login-with-sso` – Retorna a URL de redirecionamento para login com Google, Microsoft ou GitHub.
 
 ## Running Tests 🧪
 

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -17,6 +17,7 @@ class OAuthProvider(str, Enum):
 
     GOOGLE = "google"
     MICROSOFT = "azure"
+    GITHUB = "github"
 
 
 class UserSSOAuth(BaseModel):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -59,6 +59,14 @@ def test_login_with_sso_microsoft_success(mocker):
     assert response.json() == {"redirect_url": "http://example.com"}
 
 
+def test_login_with_sso_github_success(mocker):
+    mocker.patch.object(auth_module.AuthService, "login_with_sso", return_value={"url": "http://example.com"})
+    data = {"provider": "github", "redirect_to": "http://localhost"}
+    response = client.post("/login-with-sso", json=data)
+    assert response.status_code == 200
+    assert response.json() == {"redirect_url": "http://example.com"}
+
+
 def test_login_with_sso_failure(mocker):
     mocker.patch.object(auth_module.AuthService, "login_with_sso", side_effect=Exception("fail"))
     data = {"provider": "google", "redirect_to": "http://localhost"}


### PR DESCRIPTION
## Summary
- allow GitHub as an OAuth provider
- document GitHub SSO option in README
- test GitHub SSO route

## Testing
- `PYTHONPATH=src python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2caaf594832d881fc15a6b4285dc